### PR TITLE
Text editor: find the match also on the request pane

### DIFF
--- a/src/main/java/cys4/model/ExtensionEntity.java
+++ b/src/main/java/cys4/model/ExtensionEntity.java
@@ -11,22 +11,23 @@ import java.util.regex.Pattern;
 
 public class ExtensionEntity {
     private boolean active;
-    private String extension;
-    private transient Pattern extension_regex_compiled;
+    private final String regex;
+    private transient Pattern regexCompiled;
     private final String description;
 
-    public ExtensionEntity(String description, String extension) {
-        this(description, extension, true);
+    public ExtensionEntity(String description, String regex) {
+        this(description, regex, true);
     }
 
-    public ExtensionEntity(String description, String extension, boolean active) {
+    public ExtensionEntity(String description, String regex, boolean active) {
         this.active = active;
-        this.extension = extension;
         this.description = description;
-        this.extension_regex_compiled = null;
+        this.regexCompiled = null;
 
-        if (this.extension != null && !this.extension.isBlank() && !this.extension.endsWith("$")) {
-            this.extension += '$';
+        if (regex != null && !regex.isBlank() && !regex.endsWith("$")) {
+            this.regex = regex + '$';
+        } else {
+            this.regex = regex;
         }
     }
 
@@ -56,9 +57,9 @@ public class ExtensionEntity {
     }
 
     public void compileRegex() {
-        if (this.extension == null || this.extension.equals("")) return;
+        if (this.regex == null || this.regex.equals("")) return;
 
-        this.extension_regex_compiled = Pattern.compile(this.extension);
+        this.regexCompiled = Pattern.compile(this.regex);
     }
 
     public boolean isActive() {
@@ -69,12 +70,12 @@ public class ExtensionEntity {
         return this.description;
     }
 
-    public String getExtension() {
-        return this.extension;
+    public String getRegex() {
+        return this.regex;
     }
 
     public Pattern getRegexCompiled() {
-        return this.extension_regex_compiled;
+        return this.regexCompiled;
     }
 
     public void setActive(boolean value) {
@@ -86,11 +87,11 @@ public class ExtensionEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ExtensionEntity that = (ExtensionEntity) o;
-        return getExtension().equals(that.getExtension());
+        return this.getRegex().equals(that.getRegex());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getExtension());
+        return Objects.hash(getRegex());
     }
 }

--- a/src/main/java/cys4/model/LogEntity.java
+++ b/src/main/java/cys4/model/LogEntity.java
@@ -19,14 +19,16 @@ public class LogEntity {
     private final String host;
     private final int port;
     private final boolean isSSL;
+    private final String description;
 
-    public LogEntity(IHttpRequestResponse requestResponse, URL url, String regex, String match) {
+    public LogEntity(IHttpRequestResponse requestResponse, URL url, String description, String regex, String match) {
         this.idRequest = getCounterIdRequest();
 
         incrementCounter();
 
         this.requestResponse = requestResponse;
         this.url = url;
+        this.description = description;
         this.regex = regex;
         this.match = match;
         this.host = requestResponse.getHttpService().getHost();
@@ -122,5 +124,9 @@ public class LogEntity {
         return (((LogEntity) o).regex.equals(this.regex)) &&
                 firstUrl.equals(secondUrl) &&
                 ((LogEntity) o).match.equals(this.match);
+    }
+
+    public String getDescription() {
+        return this.description;
     }
 }

--- a/src/main/java/cys4/model/RegexEntity.java
+++ b/src/main/java/cys4/model/RegexEntity.java
@@ -9,9 +9,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class RegexEntity {
-    private Boolean active;
-    private final String regular_expression;
-    private transient Pattern regex_compiled;
+    private boolean active;
+    private final String regex;
+    private transient Pattern regexCompiled;
     private final String description;
 
     public RegexEntity(String description, String regex) {
@@ -20,8 +20,8 @@ public class RegexEntity {
 
     public RegexEntity(String description, String regex, Boolean active) {
         this.active = active;
-        this.regular_expression = regex;
-        this.regex_compiled = null;
+        this.regex = regex;
+        this.regexCompiled = null;
         this.description = description;
     }
 
@@ -39,9 +39,9 @@ public class RegexEntity {
     }
 
     public void compileRegex() {
-        if (this.regular_expression == null || this.regular_expression.equals("")) return;
+        if (this.regex == null || this.regex.equals("")) return;
 
-        this.regex_compiled = Pattern.compile(this.getRegex());
+        this.regexCompiled = Pattern.compile(this.getRegex());
     }
 
     public Boolean isActive() {
@@ -49,18 +49,18 @@ public class RegexEntity {
     }
 
     public String getRegex() {
-        return this.regular_expression;
+        return this.regex;
     }
 
     public Pattern getRegexCompiled() {
-        return this.regex_compiled;
+        return this.regexCompiled;
     }
 
     public String getDescription() {
         return this.description;
     }
 
-    public void setActive(Boolean value) {
+    public void setActive(boolean value) {
         this.active = value;
     }
 
@@ -69,11 +69,11 @@ public class RegexEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RegexEntity that = (RegexEntity) o;
-        return regular_expression.equals(that.regular_expression);
+        return this.getRegex().equals(that.getRegex());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(regular_expression);
+        return Objects.hash(regex);
     }
 }

--- a/src/main/java/cys4/resources/extension.json
+++ b/src/main/java/cys4/resources/extension.json
@@ -2,311 +2,311 @@
   {
     "active": true,
     "description": "Potential cryptographic private key",
-    "extension": "\\.pem"
+    "regex": "\\.pem"
   },
   {
     "active": true,
     "description": "Log file",
-    "extension": "\\.log"
+    "regex": "\\.log"
   },
   {
     "active": true,
     "description": "Potential cryptographic key bundle",
-    "extension": "\\.pkcs12"
+    "regex": "\\.pkcs12"
   },
   {
     "active": true,
     "description": "Potential cryptographic key bundle",
-    "extension": "\\.p12"
+    "regex": "\\.p12"
   },
   {
     "active": true,
     "description": "Potential cryptographic key bundle",
-    "extension": "\\.pfx"
+    "regex": "\\.pfx"
   },
   {
     "active": true,
     "description": "Potential cryptographic key bundle",
-    "extension": "\\.asc"
+    "regex": "\\.asc"
   },
   {
     "active": true,
     "description": "Potential private key",
-    "extension": "otr.private_key"
+    "regex": "otr.private_key"
   },
   {
     "active": true,
     "description": "OpenVPN client configuration file",
-    "extension": "\\.ovpn"
+    "regex": "\\.ovpn"
   },
   {
     "active": true,
     "description": "Azure service configuration schema file",
-    "extension": "\\.cscfg"
+    "regex": "\\.cscfg"
   },
   {
     "active": true,
     "description": "Remote Desktop connection file",
-    "extension": "\\.rdp"
+    "regex": "\\.rdp"
   },
   {
     "active": true,
     "description": "Microsoft SQL database file",
-    "extension": "\\.mdf"
+    "regex": "\\.mdf"
   },
   {
     "active": true,
     "description": "Microsoft SQL server compact database file",
-    "extension": "\\.sdf"
+    "regex": "\\.sdf"
   },
   {
     "active": true,
     "description": "SQLite database file",
-    "extension": "\\.sqlite"
+    "regex": "\\.sqlite"
   },
   {
     "active": true,
     "description": "SQLite3 database file",
-    "extension": "\\.sqlite3"
+    "regex": "\\.sqlite3"
   },
   {
     "active": true,
     "description": "Microsoft BitLocker recovery key file",
-    "extension": "\\.bek"
+    "regex": "\\.bek"
   },
   {
     "active": true,
     "description": "Microsoft BitLocker Trusted Platform Module password file",
-    "extension": "\\.tpm"
+    "regex": "\\.tpm"
   },
   {
     "active": true,
     "description": "Windows BitLocker full volume encrypted data file",
-    "extension": "\\.fve"
+    "regex": "\\.fve"
   },
   {
     "active": true,
     "description": "Java keystore file",
-    "extension": "\\.jks"
+    "regex": "\\.jks"
   },
   {
     "active": true,
     "description": "Password Safe database file",
-    "extension": "\\.psafe3"
+    "regex": "\\.psafe3"
   },
   {
     "active": true,
     "description": "Ruby On Rails file",
-    "extension": "\\.rb"
+    "regex": "\\.rb"
   },
   {
     "active": true,
     "description": "Potential configuration file",
-    "extension": "\\.yml"
+    "regex": "\\.yml"
   },
   {
     "active": true,
     "description": "Python file",
-    "extension": "\\.py"
+    "regex": "\\.py"
   },
   {
     "active": true,
     "description": "1Password password manager database file",
-    "extension": "\\.agilekeychain"
+    "regex": "\\.agilekeychain"
   },
   {
     "active": true,
     "description": "Apple Keychain database file",
-    "extension": "\\.keychain"
+    "regex": "\\.keychain"
   },
   {
     "active": true,
     "description": "Network traffic capture file",
-    "extension": "\\.pcap"
+    "regex": "\\.pcap"
   },
   {
     "active": true,
     "description": "GnuCash database file",
-    "extension": "\\.gnucash"
+    "regex": "\\.gnucash"
   },
   {
     "active": true,
     "description": "XML file",
-    "extension": "\\.xml"
+    "regex": "\\.xml"
   },
   {
     "active": true,
     "description": "KDE Wallet Manager database file",
-    "extension": "\\.kwallet"
+    "regex": "\\.kwallet"
   },
   {
     "active": true,
     "description": "PHP file",
-    "extension": "\\.php"
+    "regex": "\\.php"
   },
   {
     "active": true,
     "description": "Tunnelblick VPN configuration file",
-    "extension": "\\.tblk"
+    "regex": "\\.tblk"
   },
   {
     "active": true,
     "description": "Sequel Pro MySQL database manager bookmark file",
-    "extension": "\\.plist"
+    "regex": "\\.plist"
   },
   {
     "active": true,
     "description": "Little Snitch firewall configuration file",
-    "extension": "\\.xpl"
+    "regex": "\\.xpl"
   },
   {
     "active": true,
     "description": "Day One journal file",
-    "extension": "\\.dayone"
+    "regex": "\\.dayone"
   },
   {
     "active": true,
     "description": "Text file",
-    "extension": "\\.txt"
+    "regex": "\\.txt"
   },
   {
     "active": true,
     "description": "Terraform variable config file",
-    "extension": "\\terraform.tfvars"
+    "regex": "\\terraform.tfvars"
   },
   {
     "active": true,
     "description": "Shell configuration file",
-    "extension": "\\.exports"
+    "regex": "\\.exports"
   },
   {
     "active": true,
     "description": "Shell configuration file",
-    "extension": "\\.functions"
+    "regex": "\\.functions"
   },
   {
     "active": true,
     "description": "Shell configuration file",
-    "extension": "\\.extra"
+    "regex": "\\.extra"
   },
   {
     "active": true,
     "description": "ASP configuration file",
-    "extension": "\\.asa"
+    "regex": "\\.asa"
   },
   {
     "active": true,
     "description": "Include file",
-    "extension": "\\.inc"
+    "regex": "\\.inc"
   },
   {
     "active": true,
     "description": "Configuration file",
-    "extension": "\\.config"
+    "regex": "\\.config"
   },
   {
     "active": true,
     "description": "Compressed archive file",
-    "extension": "\\.zip"
+    "regex": "\\.zip"
   },
   {
     "active": true,
     "description": "Compressed archive file",
-    "extension": "\\.tar"
+    "regex": "\\.tar"
   },
   {
     "active": true,
     "description": "Compressed archive file",
-    "extension": "\\.gz"
+    "regex": "\\.gz"
   },
   {
     "active": true,
     "description": "Compressed archive file",
-    "extension": "\\.tgz"
+    "regex": "\\.tgz"
   },
   {
     "active": true,
     "description": "Compressed archive file",
-    "extension": "\\.rar"
+    "regex": "\\.rar"
   },
   {
     "active": true,
     "description": "Java file",
-    "extension": "\\.java"
+    "regex": "\\.java"
   },
   {
     "active": true,
     "description": "PDF file",
-    "extension": "\\.pdf"
+    "regex": "\\.pdf"
   },
   {
     "active": true,
     "description": "Document file",
-    "extension": "\\.docx"
+    "regex": "\\.docx"
   },
   {
     "active": true,
     "description": "Document file",
-    "extension": "\\.doc"
+    "regex": "\\.doc"
   },
   {
     "active": true,
     "description": "Document file",
-    "extension": "\\.rtf"
+    "regex": "\\.rtf"
   },
   {
     "active": true,
     "description": "Excel file",
-    "extension": "\\.xlsx"
+    "regex": "\\.xlsx"
   },
   {
     "active": true,
     "description": "Excel file",
-    "extension": "\\.xls"
+    "regex": "\\.xls"
   },
   {
     "active": true,
     "description": "Excel file",
-    "extension": "\\.csv"
+    "regex": "\\.csv"
   },
   {
     "active": true,
     "description": "Presentation file",
-    "extension": "\\.pptx"
+    "regex": "\\.pptx"
   },
   {
     "active": true,
     "description": "Presentation file",
-    "extension": "\\.ppt"
+    "regex": "\\.ppt"
   },
   {
     "active": true,
     "description": "Backup file",
-    "extension": "\\.bak"
+    "regex": "\\.bak"
   },
   {
     "active": true,
     "description": "Old file",
-    "extension": "\\.old"
+    "regex": "\\.old"
   },
   {
     "active": true,
     "description": "Temporary file",
-    "extension": "\\.tmp"
+    "regex": "\\.tmp"
   },
   {
     "active": true,
     "description": "Certificate file",
-    "extension": "\\.cer"
+    "regex": "\\.cer"
   },
   {
     "active": true,
     "description": "Certificate file",
-    "extension": "\\.crt"
+    "regex": "\\.crt"
   },
   {
     "active": true,
     "description": "Certificate file",
-    "extension": "\\.p7b"
+    "regex": "\\.p7b"
   }
 ]

--- a/src/main/java/cys4/resources/regex.json
+++ b/src/main/java/cys4/resources/regex.json
@@ -2,536 +2,536 @@
   {
     "active": true,
     "description": "Stripe API key",
-    "regular_expression": "(?:r|s)k_[live|test]_[0-9a-zA-Z]{24}"
+    "regex": "(?:r|s)k_[live|test]_[0-9a-zA-Z]{24}"
   },
   {
     "active": true,
     "description": "Private SSH key",
-    "regular_expression": "^.*_rsa"
+    "regex": "^.*_rsa"
   },
   {
     "active": true,
     "description": "Private SSH key",
-    "regular_expression": "^.*_dsa"
+    "regex": "^.*_dsa"
   },
   {
     "active": true,
     "description": "Private SSH key",
-    "regular_expression": "^.*_ed25519"
+    "regex": "^.*_ed25519"
   },
   {
     "active": true,
     "description": "Private SSH key",
-    "regular_expression": "^.*_ecdsa"
+    "regex": "^.*_ecdsa"
   },
   {
     "active": true,
     "description": "SSH configuration file",
-    "regular_expression": "\\.?ssh/config$"
+    "regex": "\\.?ssh/config$"
   },
   {
     "active": true,
     "description": "Potential cryptographic private key",
-    "regular_expression": "^key(pair)?$"
+    "regex": "^key(pair)?$"
   },
   {
     "active": true,
     "description": "Shell command history file",
-    "regular_expression": "\\.?(bash_|zsh_|sh_|z)+history"
+    "regex": "\\.?(bash_|zsh_|sh_|z)+history"
   },
   {
     "active": true,
     "description": "MySQL client command history file",
-    "regular_expression": "(\\.)?mysql_history"
+    "regex": "(\\.)?mysql_history"
   },
   {
     "active": true,
     "description": "PostgreSQL client command history file",
-    "regular_expression": "(\\.)?psql_history"
+    "regex": "(\\.)?psql_history"
   },
   {
     "active": true,
     "description": "PostgreSQL password file",
-    "regular_expression": "(\\.)?pgpass"
+    "regex": "(\\.)?pgpass"
   },
   {
     "active": true,
     "description": "Ruby IRB console history file",
-    "regular_expression": "(\\.)?irb_history"
+    "regex": "(\\.)?irb_history"
   },
   {
     "active": true,
     "description": "Pidgin chat client account configuration file",
-    "regular_expression": "\\.?purple/accounts\\.xml"
+    "regex": "\\.?purple/accounts\\.xml"
   },
   {
     "active": true,
     "description": "Hexchat/XChat IRC client server list configuration file",
-    "regular_expression": "\\.?xchat2?/servlist.conf"
+    "regex": "\\.?xchat2?/servlist.conf"
   },
   {
     "active": true,
     "description": "Irssi IRC client configuration file",
-    "regular_expression": "\\.?irssi/config"
+    "regex": "\\.?irssi/config"
   },
   {
     "active": true,
     "description": "Recon-ng web reconnaissance framework API key database",
-    "regular_expression": "\\.?recon-ng/keys\\.db"
+    "regex": "\\.?recon-ng/keys\\.db"
   },
   {
     "active": true,
     "description": "DBeaver SQL database manager configuration file",
-    "regular_expression": "\\.?dbeaver-data-sources(-[0-9]+)?\\.xml"
+    "regex": "\\.?dbeaver-data-sources(-[0-9]+)?\\.xml"
   },
   {
     "active": true,
     "description": "Mutt e-mail client configuration file",
-    "regular_expression": "\\.?muttrc"
+    "regex": "\\.?muttrc"
   },
   {
     "active": true,
     "description": "S3cmd configuration file",
-    "regular_expression": "\\.?s3cfg"
+    "regex": "\\.?s3cfg"
   },
   {
     "active": true,
     "description": "AWS CLI credentials file",
-    "regular_expression": "\\.?aws/credentials"
+    "regex": "\\.?aws/credentials"
   },
   {
     "active": true,
     "description": "SFTP connection configuration file",
-    "regular_expression": "sftp-config(\\.json)?"
+    "regex": "sftp-config(\\.json)?"
   },
   {
     "active": true,
     "description": "T command-line Twitter client configuration file",
-    "regular_expression": "/\\.?trc[\\W]+"
+    "regex": "/\\.?trc[\\W]+"
   },
   {
     "active": true,
     "description": "Shell configuration file",
-    "regular_expression": "\\.?(bash|zsh|csh)rc"
+    "regex": "\\.?(bash|zsh|csh)rc"
   },
   {
     "active": true,
     "description": "Shell profile configuration file",
-    "regular_expression": "\\.?(bash_|zsh_)+profile"
+    "regex": "\\.?(bash_|zsh_)+profile"
   },
   {
     "active": true,
     "description": "Shell command alias configuration file",
-    "regular_expression": "\\.?(bash_|zsh_)+aliases"
+    "regex": "\\.?(bash_|zsh_)+aliases"
   },
   {
     "active": true,
     "description": "PHP configuration file",
-    "regular_expression": "config(\\.inc)?\\.php"
+    "regex": "config(\\.inc)?\\.php"
   },
   {
     "active": true,
     "description": "GNOME Keyring database file",
-    "regular_expression": "key(store|ring)[\\W]+"
+    "regex": "key(store|ring)[\\W]+"
   },
   {
     "active": true,
     "description": "KeePass password manager database file",
-    "regular_expression": "\\.kdbx?"
+    "regex": "\\.kdbx?"
   },
   {
     "active": true,
     "description": "SQL dump file",
-    "regular_expression": "\\.sql(dump)?"
+    "regex": "\\.sql(dump)?"
   },
   {
     "active": true,
     "description": "Apache htpasswd file",
-    "regular_expression": "\\.?htpasswd"
+    "regex": "\\.?htpasswd"
   },
   {
     "active": true,
     "description": "Configuration file for auto-login process",
-    "regular_expression": "(\\.|_)?netrc"
+    "regex": "(\\.|_)?netrc"
   },
   {
     "active": true,
     "description": "Rubygems credentials file",
-    "regular_expression": "\\.?gem/credentials"
+    "regex": "\\.?gem/credentials"
   },
   {
     "active": true,
     "description": "Tugboat DigitalOcean management tool configuration",
-    "regular_expression": "\\.?tugboat"
+    "regex": "\\.?tugboat"
   },
   {
     "active": true,
     "description": "DigitalOcean doctl command-line client configuration file",
-    "regular_expression": "doctl/config\\.yaml"
+    "regex": "doctl/config\\.yaml"
   },
   {
     "active": true,
     "description": "git-credential-store helper credentials file",
-    "regular_expression": "\\.?git-credentials"
+    "regex": "\\.?git-credentials"
   },
   {
     "active": true,
     "description": "GitHub Hub command-line client configuration file",
-    "regular_expression": "config/hub"
+    "regex": "config/hub"
   },
   {
     "active": true,
     "description": "Git configuration file",
-    "regular_expression": "\\.?gitconfig"
+    "regex": "\\.?gitconfig"
   },
   {
     "active": true,
     "description": "Chef private key",
-    "regular_expression": "\\.?chef/(.*)\\.pem"
+    "regex": "\\.?chef/(.*)\\.pem"
   },
   {
     "active": true,
     "description": "Potential Linux shadow file",
-    "regular_expression": "etc/shadow"
+    "regex": "etc/shadow"
   },
   {
     "active": true,
     "description": "Potential Linux passwd file",
-    "regular_expression": "etc/passwd"
+    "regex": "etc/passwd"
   },
   {
     "active": true,
     "description": "Docker configuration file",
-    "regular_expression": "\\.?dockercfg"
+    "regex": "\\.?dockercfg"
   },
   {
     "active": true,
     "description": "NPM configuration file",
-    "regular_expression": "\\.?npmrc"
+    "regex": "\\.?npmrc"
   },
   {
     "active": true,
     "description": "Environment configuration file",
-    "regular_expression": "\\.env"
+    "regex": "\\.env"
   },
   {
     "active": true,
     "description": "AWS Access Key ID Value",
-    "regular_expression": "(A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"
+    "regex": "(A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}"
   },
   {
     "active": true,
     "description": "Facebook OAuth",
-    "regular_expression": "[f|F][a|A][c|C][e|E][b|B][o|O][o|O][k|K].*['|\"][0-9a-f]{32}['|\"]"
+    "regex": "[f|F][a|A][c|C][e|E][b|B][o|O][o|O][k|K].*['|\"][0-9a-f]{32}['|\"]"
   },
   {
     "active": true,
     "description": "Firebase URL",
-    "regular_expression": "[a-z0-9.-]+\\.firebaseio\\.com"
+    "regex": "[a-z0-9.-]+\\.firebaseio\\.com"
   },
   {
     "active": true,
     "description": "GitHub",
-    "regular_expression": "[g|G][i|I][t|T][h|H][u|U][b|B].*['|\"][0-9a-zA-Z]{35,40}['|\"]"
+    "regex": "[g|G][i|I][t|T][h|H][u|U][b|B].*['|\"][0-9a-zA-Z]{35,40}['|\"]"
   },
   {
     "active": true,
     "description": "Generic API Key",
-    "regular_expression": "[a|A][p|P][i|I][_]?[k|K][e|E][y|Y].*['|\"][0-9a-zA-Z]{32,45}['|\"]"
+    "regex": "[a|A][p|P][i|I][_]?[k|K][e|E][y|Y].*['|\"][0-9a-zA-Z]{32,45}['|\"]"
   },
   {
     "active": true,
     "description": "Generic Secret",
-    "regular_expression": "[s|S][e|E][c|C][r|R][e|E][t|T].*['|\"][0-9a-zA-Z]{32,45}['|\"]"
+    "regex": "[s|S][e|E][c|C][r|R][e|E][t|T].*['|\"][0-9a-zA-Z]{32,45}['|\"]"
   },
   {
     "active": true,
     "description": "IP Address",
-    "regular_expression": "[^\\.0-9](([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])[^\\.0-9]"
+    "regex": "[^\\.0-9](([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])[^\\.0-9]"
   },
   {
     "active": true,
     "description": "Facebook access token",
-    "regular_expression": "EAACEdEose0cBA[0-9A-Za-z]+"
+    "regex": "EAACEdEose0cBA[0-9A-Za-z]+"
   },
   {
     "active": true,
     "description": "Google OAuth Key",
-    "regular_expression": "[0-9]+-[0-9A-Za-z_]{32}\\.apps\\.googleusercontent\\.com"
+    "regex": "[0-9]+-[0-9A-Za-z_]{32}\\.apps\\.googleusercontent\\.com"
   },
   {
     "active": true,
     "description": "Google Cloud API Key",
-    "regular_expression": "AIza[0-9A-Za-z\\\\\\-\\_]{35}"
+    "regex": "AIza[0-9A-Za-z\\\\\\-\\_]{35}"
   },
   {
     "active": true,
     "description": "Google OAuth Access Token",
-    "regular_expression": "ya29\\.[0-9A-Za-z\\\\-_]+"
+    "regex": "ya29\\.[0-9A-Za-z\\\\-_]+"
   },
   {
     "active": true,
     "description": "Picatic API key",
-    "regular_expression": "sk_(live|test)_[0-9a-z]{32}"
+    "regex": "sk_(live|test)_[0-9a-z]{32}"
   },
   {
     "active": true,
     "description": "Square Access Token",
-    "regular_expression": "sq0atp-[0-9A-Za-z\\-_]{22}"
+    "regex": "sq0atp-[0-9A-Za-z\\-_]{22}"
   },
   {
     "active": true,
     "description": "Square OAuth Secret",
-    "regular_expression": "sq0csp-[0-9A-Za-z\\-_]{43}"
+    "regex": "sq0csp-[0-9A-Za-z\\-_]{43}"
   },
   {
     "active": true,
     "description": "PayPal/Braintree Access Token",
-    "regular_expression": "access_token\\$production\\$[0-9a-z]{16}\\$[0-9a-f]{32}"
+    "regex": "access_token\\$production\\$[0-9a-z]{16}\\$[0-9a-f]{32}"
   },
   {
     "active": true,
     "description": "Amazon MWS Auth Token",
-    "regular_expression": "amzn\\.mws\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    "regex": "amzn\\.mws\\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
   },
   {
     "active": true,
     "description": "Twilio API Key",
-    "regular_expression": "SK[0-9a-fA-F]{32}"
+    "regex": "SK[0-9a-fA-F]{32}"
   },
   {
     "active": true,
     "description": "SendGrid API Key",
-    "regular_expression": "SG\\.[0-9A-Za-z\\-_]{22}\\.[0-9A-Za-z\\-_]{43}"
+    "regex": "SG\\.[0-9A-Za-z\\-_]{22}\\.[0-9A-Za-z\\-_]{43}"
   },
   {
     "active": true,
     "description": "MailGun API Key",
-    "regular_expression": "key-[0-9a-zA-Z]{32}"
+    "regex": "key-[0-9a-zA-Z]{32}"
   },
   {
     "active": true,
     "description": "MailChimp API Key",
-    "regular_expression": "[0-9a-f]{32}-us[0-9]{12}"
+    "regex": "[0-9a-f]{32}-us[0-9]{12}"
   },
   {
     "active": true,
     "description": "SSH Password",
-    "regular_expression": "sshpass -p .*['|\\\\\\\"]"
+    "regex": "sshpass -p .*['|\\\\\\\"]"
   },
   {
     "active": true,
     "description": "Outlook team",
-    "regular_expression": "(https://outlook\\.office\\.com/webhook/[0-9a-f-]{36}@)"
+    "regex": "(https://outlook\\.office\\.com/webhook/[0-9a-f-]{36}@)"
   },
   {
     "active": true,
     "description": "Slack Token",
-    "regular_expression": "(xox[pboa]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})"
+    "regex": "(xox[pboa]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})"
   },
   {
     "active": true,
     "description": "Slack Webhook",
-    "regular_expression": "https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}"
+    "regex": "https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}"
   },
   {
     "active": true,
     "description": "NuGet API Key",
-    "regular_expression": "oy2[a-z0-9]{43}"
+    "regex": "oy2[a-z0-9]{43}"
   },
   {
     "active": true,
     "description": "Created by remote-sync for Atom, contains FTP and/or SCP/SFTP/SSH server details and credentials",
-    "regular_expression": ".remote-sync.json"
+    "regex": ".remote-sync.json"
   },
   {
     "active": true,
     "description": "esmtp configuration",
-    "regular_expression": ".esmtprc"
+    "regex": ".esmtprc"
   },
   {
     "active": true,
     "description": "Created by sftp-deployment for Atom, contains server details and credentials",
-    "regular_expression": "(deployment-config(\\.json)?|\\.ftpconfig)"
+    "regex": "(deployment-config(\\.json)?|\\.ftpconfig)"
   },
   {
     "active": true,
     "description": "Contains a private key",
-    "regular_expression": "-----BEGIN (EC|RSA|DSA|OPENSSH|PGP) PRIVATE KEY"
+    "regex": "-----BEGIN (EC|RSA|DSA|OPENSSH|PGP) PRIVATE KEY"
   },
   {
     "active": true,
     "description": "WP-Config",
-    "regular_expression": "define(.{0,20})?(DB_CHARSET|NONCE_SALT|LOGGED_IN_SALT|AUTH_SALT|NONCE_KEY|DB_HOST|DB_PASSWORD|AUTH_KEY|SECURE_AUTH_KEY|LOGGED_IN_KEY|DB_NAME|DB_USER)(.{0,20})?[''|\"].{10,120}[''|\"]"
+    "regex": "define(.{0,20})?(DB_CHARSET|NONCE_SALT|LOGGED_IN_SALT|AUTH_SALT|NONCE_KEY|DB_HOST|DB_PASSWORD|AUTH_KEY|SECURE_AUTH_KEY|LOGGED_IN_KEY|DB_NAME|DB_USER)(.{0,20})?[''|\"].{10,120}[''|\"]"
   },
   {
     "active": true,
     "description": "Created by Jetbrains IDEs, contains webserver credentials with encoded passwords (not encrypted!)",
-    "regular_expression": "\\.?idea[\\\\\\/]WebServers\\.xml"
+    "regex": "\\.?idea[\\\\\\/]WebServers\\.xml"
   },
   {
     "active": true,
     "description": "Created by vscode-sftp for VSCode, contains SFTP/SSH server details and credentials",
-    "regular_expression": "\\.?vscode[\\\\\\/]sftp\\.json"
+    "regex": "\\.?vscode[\\\\\\/]sftp\\.json"
   },
   {
     "active": true,
     "description": "Ruby on rails secrets.yml file (contains passwords)",
-    "regular_expression": "web[\\\\\\/]ruby[\\\\\\/]secrets\\.yml"
+    "regex": "web[\\\\\\/]ruby[\\\\\\/]secrets\\.yml"
   },
   {
     "active": true,
     "description": "Docker registry authentication file",
-    "regular_expression": "\\.?docker[\\\\\\/]config\\.json"
+    "regex": "\\.?docker[\\\\\\/]config\\.json"
   },
   {
     "active": true,
     "description": "Rails master key (used for decrypting credentials.yml.enc for Rails 5.2+)",
-    "regular_expression": "ruby[\\\\\\/]config[\\\\\\/]master\\.key"
+    "regex": "ruby[\\\\\\/]config[\\\\\\/]master\\.key"
   },
   {
     "active": true,
     "description": "Firefox saved password collection (can be decrypted using keys4.db)",
-    "regular_expression": "\\.?mozilla[\\\\\\/]firefox[\\\\\\/]logins\\.json"
+    "regex": "\\.?mozilla[\\\\\\/]firefox[\\\\\\/]logins\\.json"
   },
   {
     "active": true,
     "description": "AWS Access Key ID",
-    "regular_expression": "(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])"
+    "regex": "(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])"
   },
   {
     "active": true,
     "description": "AWS ARN",
-    "regular_expression": "arn:aws:organizations::\\d{12}:account\\/o-[a-z0-9]{10,32}\\/\\d{12}"
+    "regex": "arn:aws:organizations::\\d{12}:account\\/o-[a-z0-9]{10,32}\\/\\d{12}"
   },
   {
     "active": true,
     "description": "AWS Secret Access Key",
-    "regular_expression": "(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])"
+    "regex": "(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])"
   },
   {
     "active": true,
     "description": "AWS Session Token",
-    "regular_expression": "(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{16,}(?<![A-Za-z0-9/+=])"
+    "regex": "(?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{16,}(?<![A-Za-z0-9/+=])"
   },
   {
     "active": true,
     "description": "Artifactory",
-    "regular_expression": "(?i)artifactory.{0,50}(\"|'|`)?[a-zA-Z0-9=]{112}(\"|'|`)?"
+    "regex": "(?i)artifactory.{0,50}(\"|'|`)?[a-zA-Z0-9=]{112}(\"|'|`)?"
   },
   {
     "active": true,
     "description": "CodeClimate",
-    "regular_expression": "(?i)codeclima.{0,50}(\"|'|`)?[0-9a-f]{64}(\"|'|`)?"
+    "regex": "(?i)codeclima.{0,50}(\"|'|`)?[0-9a-f]{64}(\"|'|`)?"
   },
   {
     "active": true,
     "description": "Google (GCM) Service account",
-    "regular_expression": "((\"|'|`)?type(\"|'|`)?\\s{0,50}(:|=>|=)\\s{0,50}(\"|'|`)?service_account(\"|'|`)?,?)"
+    "regex": "((\"|'|`)?type(\"|'|`)?\\s{0,50}(:|=>|=)\\s{0,50}(\"|'|`)?service_account(\"|'|`)?,?)"
   },
   {
     "active": true,
     "description": "Sauce Token",
-    "regular_expression": "(?i)sauce.{0,50}(\"|'|`)?[0-9a-f-]{36}(\"|'|`)?"
+    "regex": "(?i)sauce.{0,50}(\"|'|`)?[0-9a-f-]{36}(\"|'|`)?"
   },
   {
     "active": true,
     "description": "SonarQube Docs API Key",
-    "regular_expression": "(?i)sonar.{0,50}(\"|'|`)?[0-9a-f]{40}(\"|'|`)?"
+    "regex": "(?i)sonar.{0,50}(\"|'|`)?[0-9a-f]{40}(\"|'|`)?"
   },
   {
     "active": true,
     "description": "HockeyApp",
-    "regular_expression": "(?i)hockey.{0,50}(\"|'|`)?[0-9a-f]{32}(\"|'|`)?"
+    "regex": "(?i)hockey.{0,50}(\"|'|`)?[0-9a-f]{32}(\"|'|`)?"
   },
   {
     "active": true,
     "description": "Username and password in URI",
-    "regular_expression": "([\\w+]{1,24})(://)([^$<]{1})([^\\s\";]{1,}):([^$<]{1})([^\\s\";/]{1,})@[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,24}([^\\s]+)"
+    "regex": "([\\w+]{1,24})(://)([^$<]{1})([^\\s\";]{1,}):([^$<]{1})([^\\s\";/]{1,})@[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,24}([^\\s]+)"
   },
   {
     "active": true,
     "description": "StackHawk API Key",
-    "regular_expression": "hawk\\.[0-9A-Za-z\\-_]{20}\\.[0-9A-Za-z\\-_]{20}"
+    "regex": "hawk\\.[0-9A-Za-z\\-_]{20}\\.[0-9A-Za-z\\-_]{20}"
   },
   {
     "active": true,
     "description": "AWS cred file info",
-    "regular_expression": "(?i)(aws_access_key_id|aws_secret_access_key)(.{0,20})?=.[0-9a-zA-Z\\/+]{20,40}"
+    "regex": "(?i)(aws_access_key_id|aws_secret_access_key)(.{0,20})?=.[0-9a-zA-Z\\/+]{20,40}"
   },
   {
     "active": true,
     "description": "Facebook Secret Key",
-    "regular_expression": "(?i)(facebook|fb)(.{0,20})?(?-i)[''\"][0-9a-f]{32}[''\"]"
+    "regex": "(?i)(facebook|fb)(.{0,20})?(?-i)[''\"][0-9a-f]{32}[''\"]"
   },
   {
     "active": true,
     "description": "Facebook Client ID",
-    "regular_expression": "(?i)(facebook|fb)(.{0,20})?[''\"][0-9]{13,17}[''\"]"
+    "regex": "(?i)(facebook|fb)(.{0,20})?[''\"][0-9]{13,17}[''\"]"
   },
   {
     "active": true,
     "description": "Twitter Secret Key",
-    "regular_expression": "(?i)twitter(.{0,20})?[''\"][0-9a-z]{35,44}[''\"]"
+    "regex": "(?i)twitter(.{0,20})?[''\"][0-9a-z]{35,44}[''\"]"
   },
   {
     "active": true,
     "description": "Twitter Client ID",
-    "regular_expression": "(?i)twitter(.{0,20})?[''\"][0-9a-z]{18,25}[''\"]"
+    "regex": "(?i)twitter(.{0,20})?[''\"][0-9a-z]{18,25}[''\"]"
   },
   {
     "active": true,
     "description": "Twitter Access Token",
-    "regular_expression": "[t|T][w|W][i|I][t|T][t|T][e|E][r|R].*[1-9][0-9]+-[0-9a-zA-Z]{40}"
+    "regex": "[t|T][w|W][i|I][t|T][t|T][e|E][r|R].*[1-9][0-9]+-[0-9a-zA-Z]{40}"
   },
   {
     "active": true,
     "description": "Twitter OAuth",
-    "regular_expression": "[t|T][w|W][i|I][t|T][t|T][e|E][r|R].*['|\"][0-9a-zA-Z]{35,44}['|\"]"
+    "regex": "[t|T][w|W][i|I][t|T][t|T][e|E][r|R].*['|\"][0-9a-zA-Z]{35,44}['|\"]"
   },
   {
     "active": true,
     "description": "Github Key",
-    "regular_expression": "(?i)github(.{0,20})?(?-i)[''\"][0-9a-zA-Z]{35,40}[''\"]"
+    "regex": "(?i)github(.{0,20})?(?-i)[''\"][0-9a-zA-Z]{35,40}[''\"]"
   },
   {
     "active": true,
     "description": "Heroku Key",
-    "regular_expression": "(?i)heroku(.{0,20})?[''\"][0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}[''\"]"
+    "regex": "(?i)heroku(.{0,20})?[''\"][0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}[''\"]"
   },
   {
     "active": true,
     "description": "Linkedin Client ID",
-    "regular_expression": "(?i)linkedin(.{0,20})?(?-i)[''\"][0-9a-z]{12}[''\"]"
+    "regex": "(?i)linkedin(.{0,20})?(?-i)[''\"][0-9a-z]{12}[''\"]"
   },
   {
     "active": true,
     "description": "LinkedIn Secret Key",
-    "regular_expression": "(?i)linkedin(.{0,20})?[''\"][0-9a-z]{16}[''\"]"
+    "regex": "(?i)linkedin(.{0,20})?[''\"][0-9a-z]{16}[''\"]"
   },
   {
     "active": true,
     "description": "Password in URL",
-    "regular_expression": "[a-zA-Z]{3,10}://[^/\\s:@]{3,20}:[^/\\s:@]{3,20}@.{1,100}[\"'\\s]"
+    "regex": "[a-zA-Z]{3,10}://[^/\\s:@]{3,20}:[^/\\s:@]{3,20}@.{1,100}[\"'\\s]"
   },
   {
     "active": true,
     "description": "Authorization Bearer - 1",
-    "regular_expression": "Bearer\\s[\\d|a-f]{8}-([\\d|a-f]{4}-){3}[\\d|a-f]{12}"
+    "regex": "Bearer\\s[\\d|a-f]{8}-([\\d|a-f]{4}-){3}[\\d|a-f]{12}"
   },
   {
     "active": true,
     "description": "Authorization Splunk",
-    "regular_expression": "Splunk\\s(\\{){0,1}[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}(\\}){0,1}"
+    "regex": "Splunk\\s(\\{){0,1}[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}(\\}){0,1}"
   },
   {
     "active": true,
     "description": "Authorization Basic",
-    "regular_expression": "Basic\\s[a-zA-Z0-9+\\/]+\\=*"
+    "regex": "Basic\\s[a-zA-Z0-9+\\/]+\\=*"
   },
   {
     "active": true,
     "description": "Authorization Bearer - 2",
-    "regular_expression": "Bearer\\s[A-Za-z0-9\\-_=]+\\.[A-Za-z0-9\\-_=]+(\\.[A-Za-z0-9\\-_.+/=]+)?"
+    "regex": "Bearer\\s[A-Za-z0-9\\-_=]+\\.[A-Za-z0-9\\-_=]+(\\.[A-Za-z0-9\\-_.+/=]+)?"
   }
 ]

--- a/src/main/java/cys4/scanner/BurpLeaksScanner.java
+++ b/src/main/java/cys4/scanner/BurpLeaksScanner.java
@@ -130,7 +130,8 @@ public class BurpLeaksScanner {
             while (regex_matcher.find()) {
                 addLogEntry(
                     httpProxyItem,
-                    entry.getDescription() + " - " + entry.getRegex(),
+                    entry.getDescription(),
+                    entry.getRegex(),
                     regex_matcher.group());
             }
         }
@@ -141,20 +142,18 @@ public class BurpLeaksScanner {
             // if the box related to the extensions in the Options tab of the extension is checked
             if (!entry.isActive()) continue;
 
-            String extension = entry.getExtension();
-
             Matcher extension_matcher = entry.getRegexCompiled().matcher(requestURL.toString());
-            // add the new entry if do not exist
             if (extension_matcher.find()) {
                 addLogEntry(
                     httpProxyItem,
-                    "EXT " + entry.getDescription() + " - " + extension,
-                    extension);
+                    entry.getDescription(),
+                    entry.getRegex(),
+                    extension_matcher.group());
             }
         }
     }
 
-    private void addLogEntry(IHttpRequestResponse httpProxyItem, String description, String match) {
+    private void addLogEntry(IHttpRequestResponse httpProxyItem, String description, String regex, String match) {
         // create a new log entry with the message details
         int row = logEntries.size();
 
@@ -163,6 +162,7 @@ public class BurpLeaksScanner {
             httpProxyItem,
             helpers.analyzeRequest(httpProxyItem).getUrl(),
             description,
+            regex,
             match);
 
         if (!logEntries.contains(logEntry)) {

--- a/src/main/java/cys4/seed/BurpLeaksSeed.java
+++ b/src/main/java/cys4/seed/BurpLeaksSeed.java
@@ -34,7 +34,7 @@ public class BurpLeaksSeed {
         List<ExtensionEntity> lDeserializedJson = _gson.fromJson(Utils.readResourceFile("extension.json"), tArrayListExtensionEntity);
 
         for (ExtensionEntity element : lDeserializedJson) {
-            extensions.add(new ExtensionEntity(element.getDescription(), element.getExtension(), element.isActive()));
+            extensions.add(new ExtensionEntity(element.getDescription(), element.getRegex(), element.isActive()));
         }
     }
 

--- a/src/main/java/cys4/ui/ContextMenuUI.java
+++ b/src/main/java/cys4/ui/ContextMenuUI.java
@@ -18,9 +18,6 @@ import java.util.List;
 public class ContextMenuUI extends JPopupMenu {
 
     public ContextMenuUI(LogEntity le, List<LogEntity> logEntries, ITextEditor originalRequestViewer, ITextEditor originalResponseViewer, LogTableEntriesUI logTableEntriesUI, LogTableEntryUI logTableEntryUI,IBurpExtenderCallbacks callbacks) {
-
-        // init params
-
         // populate the menu
         String urlLog = le.getURL().toString();
         if (urlLog.length() > 50) urlLog = urlLog.substring(0, 47) + "...";
@@ -82,6 +79,15 @@ public class ContextMenuUI extends JPopupMenu {
             @Override
             public void actionPerformed(final ActionEvent e) {
                 StringSelection stsel = new StringSelection(le.getURL().toString());
+                Clipboard system = Toolkit.getDefaultToolkit().getSystemClipboard();
+                system.setContents(stsel, stsel);
+            }
+        }));
+
+        this.add(new JMenuItem(new AbstractAction("Copy Description") {
+            @Override
+            public void actionPerformed(final ActionEvent e) {
+                StringSelection stsel = new StringSelection(le.getDescription());
                 Clipboard system = Toolkit.getDefaultToolkit().getSystemClipboard();
                 system.setContents(stsel, stsel);
             }

--- a/src/main/java/cys4/ui/LogTableEntriesUI.java
+++ b/src/main/java/cys4/ui/LogTableEntriesUI.java
@@ -55,7 +55,7 @@ public class LogTableEntriesUI extends AbstractTableModel {
         return switch (columnIndex) {
             case 0 -> logEntity.getIdRequest();
             case 1 -> logEntity.getURL().toString();
-            case 2 -> logEntity.getRegex();
+            case 2 -> logEntity.getDescription() + " - "  + logEntity.getRegex();
             case 3 -> logEntity.getMatch();
             default -> "";
         };

--- a/src/main/java/cys4/ui/LogTableEntryUI.java
+++ b/src/main/java/cys4/ui/LogTableEntryUI.java
@@ -50,13 +50,9 @@ public class LogTableEntryUI extends JTable {
     public void updateRequestViewers(byte[] request, byte[] response, String search) {
         SwingUtilities.invokeLater(() -> {
             originalRequestViewer.setText(Objects.requireNonNullElseGet(request, () -> new byte[0]));
-
-            if (response != null) {
-                originalResponseViewer.setText(response);
-                originalResponseViewer.setSearchExpression(search);
-            } else {
-                originalResponseViewer.setText(new byte[0]);
-            }
+            originalRequestViewer.setSearchExpression(search);
+            originalResponseViewer.setText(Objects.requireNonNullElseGet(response, () -> new byte[0]));
+            originalResponseViewer.setSearchExpression(search);
         });
     }
 }

--- a/src/main/java/cys4/ui/OptionsExtTableModelUI.java
+++ b/src/main/java/cys4/ui/OptionsExtTableModelUI.java
@@ -5,7 +5,6 @@ See the file 'LICENSE' for copying permission
 package cys4.ui;
 
 import cys4.model.ExtensionEntity;
-
 import javax.swing.table.AbstractTableModel;
 import java.util.List;
 
@@ -56,7 +55,7 @@ public class OptionsExtTableModelUI extends AbstractTableModel {
 
         return switch (columnIndex) {
             case 0 -> extensionEntry.isActive();
-            case 1 -> extensionEntry.getExtension();
+            case 1 -> extensionEntry.getRegex();
             case 2 -> extensionEntry.getDescription();
             default -> "";
         };


### PR DESCRIPTION
- When matching extensions, the extension wasn't matched in the request;
- Separated the regex's description from the regex itself. It's now possible to copy both independently;
- Renamed variables to ease future refactoring.