### PR TITLE
Option to change scanner's number of threads

### DIFF
--- a/src/main/java/cys4/scanner/BurpLeaksScanner.java
+++ b/src/main/java/cys4/scanner/BurpLeaksScanner.java
@@ -38,13 +38,15 @@ public class BurpLeaksScanner {
     private ArrayList<String> blacklistedMimeTypes;
     private final Gson gson;
     private boolean interruptScan;
+    private int numThreads;
 
     // analyzeProxyHistory
     private int analyzedItems = 0;
     private final Object analyzeLock = new Object();
 
-    public BurpLeaksScanner(MainUI mainUI, IBurpExtenderCallbacks callbacks, List<LogEntity> logEntries,
+    public BurpLeaksScanner(int numThreads, MainUI mainUI, IBurpExtenderCallbacks callbacks, List<LogEntity> logEntries,
             List<RegexEntity> regexList, List<ExtensionEntity> extensionsList) {
+        this.numThreads = numThreads;
         this.mainUI = mainUI;
         this.callbacks = callbacks;
         this.helpers = callbacks.getHelpers();
@@ -77,7 +79,7 @@ public class BurpLeaksScanner {
 
         LogEntity.setIdRequest(0); // responseId will start at 0
 
-        ExecutorService executor = Executors.newFixedThreadPool(4);
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
 
         for (IHttpRequestResponse httpProxyItem : httpRequests) {
             executor.execute(() -> {
@@ -212,5 +214,13 @@ public class BurpLeaksScanner {
 
     public void setInterruptScan(boolean interruptScan) {
         this.interruptScan = interruptScan;
+    }
+
+    public int getNumThreads() {
+        return numThreads;
+    }
+
+    public void setNumThreads(int numThreads) {
+        this.numThreads = numThreads;
     }
 }


### PR DESCRIPTION
Adds a new section in the configurations of the Options tab.

This permits viewing and changing the number of threads the Scanner uses to analyze the requests.

By default, the Scanner is initialized with 4 threads. With the new option, the number can be changed to any number in the range of 1-128.