### PR TITLE
Changing lists while making an analysis cause errors

### DIFF
--- a/src/main/java/cys4/model/ExtensionEntity.java
+++ b/src/main/java/cys4/model/ExtensionEntity.java
@@ -11,23 +11,31 @@ import java.util.regex.Pattern;
 
 public class ExtensionEntity {
     private boolean active;
-    private String extension;
-    private transient Pattern extension_regex_compiled;
+    private final String extension;
+    private final transient Pattern extension_regex_compiled;
     private final String description;
 
-    public ExtensionEntity(String description, String extension) {
+    public ExtensionEntity(String description, String extension) throws IllegalArgumentException {
         this(description, extension, true);
     }
 
-    public ExtensionEntity(String description, String extension, boolean active) {
-        this.active = active;
-        this.extension = extension;
-        this.description = description;
-        this.extension_regex_compiled = null;
+    public ExtensionEntity(String description, String extension, boolean active) throws IllegalArgumentException {
+        if (extension == null || extension.isBlank())
+            throw new IllegalArgumentException("Invalid regex");
 
-        if (this.extension != null && !this.extension.isBlank() && !this.extension.endsWith("$")) {
-            this.extension += '$';
+        this.active = active;
+        this.description = description;
+
+        if (extension.endsWith("$")) {
+            this.extension = extension;
+        } else {
+            this.extension = extension + '$';
         }
+        this.extension_regex_compiled = Pattern.compile(this.extension);
+    }
+
+    public ExtensionEntity(ExtensionEntity entity) throws IllegalArgumentException {
+        this(entity.getDescription(), entity.getExtension(), entity.isActive());
     }
 
     /**
@@ -53,12 +61,6 @@ public class ExtensionEntity {
                 .compile("\\..+?")
                 .matcher(extension)
                 .find();
-    }
-
-    public void compileRegex() {
-        if (this.extension == null || this.extension.equals("")) return;
-
-        this.extension_regex_compiled = Pattern.compile(this.extension);
     }
 
     public boolean isActive() {

--- a/src/main/java/cys4/model/RegexEntity.java
+++ b/src/main/java/cys4/model/RegexEntity.java
@@ -9,20 +9,27 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class RegexEntity {
-    private Boolean active;
+    private boolean active;
     private final String regular_expression;
-    private transient Pattern regex_compiled;
+    private final transient Pattern regex_compiled;
     private final String description;
 
-    public RegexEntity(String description, String regex) {
+    public RegexEntity(String description, String regex) throws IllegalArgumentException {
         this(description, regex, true);
     }
 
-    public RegexEntity(String description, String regex, Boolean active) {
+    public RegexEntity(String description, String regex, boolean active) throws IllegalArgumentException{
+        if (regex == null || regex.isEmpty())
+            throw new IllegalArgumentException("Invalid regex");
+
         this.active = active;
-        this.regular_expression = regex;
-        this.regex_compiled = null;
         this.description = description;
+        this.regular_expression = regex;
+        this.regex_compiled = Pattern.compile(regex);
+    }
+
+    public RegexEntity(RegexEntity entity) throws IllegalArgumentException {
+        this(entity.getDescription(), entity.getRegex(), entity.isActive());
     }
 
     /**
@@ -36,12 +43,6 @@ public class RegexEntity {
         return Pattern
                 .compile("^\\s*[\"'](.*?)[\"']\\s*,\\s*[\"'](.+?)[\"']\\s*$")
                 .matcher(line);
-    }
-
-    public void compileRegex() {
-        if (this.regular_expression == null || this.regular_expression.equals("")) return;
-
-        this.regex_compiled = Pattern.compile(this.getRegex());
     }
 
     public Boolean isActive() {
@@ -60,7 +61,7 @@ public class RegexEntity {
         return this.description;
     }
 
-    public void setActive(Boolean value) {
+    public void setActive(boolean value) {
         this.active = value;
     }
 

--- a/src/main/java/cys4/scanner/BurpLeaksScanner.java
+++ b/src/main/java/cys4/scanner/BurpLeaksScanner.java
@@ -33,8 +33,8 @@ public class BurpLeaksScanner {
     private final IExtensionHelpers helpers;
     private final IBurpExtenderCallbacks callbacks;
     private final List<LogEntity> logEntries;
-    private List<RegexEntity> regexList;
-    private List<ExtensionEntity> extensionsList;
+    private final List<RegexEntity> regexList;
+    private final List<ExtensionEntity> extensionsList;
     private ArrayList<String> blacklistedMimeTypes;
     private final Gson gson;
     private boolean interruptScan;
@@ -53,14 +53,6 @@ public class BurpLeaksScanner {
         this.extensionsList = extensionsList;
         this.interruptScan = false;
         this.gson = new Gson();
-
-        for (RegexEntity entry : this.regexList) {
-            entry.compileRegex();
-        }
-
-        for (ExtensionEntity entry : this.extensionsList) {
-            entry.compileRegex();
-        }
     }
 
     /**
@@ -70,18 +62,27 @@ public class BurpLeaksScanner {
         IHttpRequestResponse[] httpRequests;
         httpRequests = callbacks.getProxyHistory();
 
-        progressBar.setMaximum(httpRequests.length);
         this.analyzedItems = 0;
+        progressBar.setMaximum(httpRequests.length);
         progressBar.setValue(this.analyzedItems);
         progressBar.setStringPainted(true);
 
-        LogEntity.setIdRequest(0); // responseId will start at 0
+        boolean inScope = MainUI.isInScopeSelected();
+        List<RegexEntity> regexListCopy = new ArrayList<>();
+        for(RegexEntity e : regexList) {
+            regexListCopy.add(new RegexEntity(e));
+        }
+        List<ExtensionEntity> extensionListCopy = new ArrayList<>();
+        for(ExtensionEntity e : extensionsList) {
+            extensionListCopy.add(new ExtensionEntity(e));
+        }
 
+        LogEntity.setIdRequest(0); // responseId will start at 0
         ExecutorService executor = Executors.newFixedThreadPool(4);
 
         for (IHttpRequestResponse httpProxyItem : httpRequests) {
             executor.execute(() -> {
-                analyzeSingleMessage(httpProxyItem);
+                analyzeSingleMessage(httpProxyItem, inScope, regexListCopy, extensionListCopy);
 
                 if (interruptScan) return;
 
@@ -109,17 +110,18 @@ public class BurpLeaksScanner {
     /**
      * The main method that scan for regex in the single request body
      */
-    private void analyzeSingleMessage(IHttpRequestResponse httpProxyItem) {
+    private void analyzeSingleMessage(IHttpRequestResponse httpProxyItem, boolean inScopeSelected, List<RegexEntity> regexList, List<ExtensionEntity> extensionsList) {
         URL requestURL = helpers.analyzeRequest(httpProxyItem).getUrl();
+        byte[] response = httpProxyItem.getResponse();
 
-        if (Objects.isNull(httpProxyItem.getResponse())) return;
-        if (MainUI.isInScopeSelected() && (!callbacks.isInScope(requestURL))) return;
+        if (Objects.isNull(response)) return;
+        if (inScopeSelected && (!callbacks.isInScope(requestURL))) return;
 
-        IResponseInfo response = helpers.analyzeResponse(httpProxyItem.getResponse());
-        if (!isValidMimeType(response.getStatedMimeType(), response.getInferredMimeType())) return;
+        IResponseInfo responseInfo = helpers.analyzeResponse(response);
+        if (!isValidMimeType(responseInfo.getStatedMimeType(), responseInfo.getInferredMimeType())) return;
 
         // convert from bytes to string the body of the request
-        String responseBody = helpers.bytesToString(httpProxyItem.getResponse());
+        String responseBody = helpers.bytesToString(response);
         for (RegexEntity entry : regexList) {
             if (this.interruptScan) return;
 
@@ -192,22 +194,6 @@ public class BurpLeaksScanner {
         }
 
         return !blacklistedMimeTypes.contains(mimeType.toUpperCase());
-    }
-
-    public void updateRegexList(List<RegexEntity> regexList) {
-        this.regexList = regexList;
-
-        for (RegexEntity entry : this.regexList) {
-            entry.compileRegex();
-        }
-    }
-
-    public void updateExtensionList(List<ExtensionEntity> extensionsList) {
-        this.extensionsList = extensionsList;
-
-        for (ExtensionEntity entry : extensionsList) {
-            entry.compileRegex();
-        }
     }
 
     public void setInterruptScan(boolean interruptScan) {

--- a/src/main/java/cys4/ui/MainUI.java
+++ b/src/main/java/cys4/ui/MainUI.java
@@ -285,26 +285,24 @@ public class MainUI implements ITab {
 
         btnAnalysis.addActionListener(actionEvent -> {
             if (!isAnalysisRunning) {
-                if (callbacks.getProxyHistory().length > 0) {
-                    this.isAnalysisRunning = true;
-                    this.analyzeProxyHistoryThread = new Thread(() -> {
-                        String previousText = btnAnalysis.getText();
-                        btnAnalysis.setText(textAnalysisStop);
-                        logTableEntryUI.setAutoCreateRowSorter(false);
+                this.isAnalysisRunning = true;
+                this.analyzeProxyHistoryThread = new Thread(() -> {
+                    String previousText = btnAnalysis.getText();
+                    btnAnalysis.setText(textAnalysisStop);
+                    logTableEntryUI.setAutoCreateRowSorter(false);
 
-                        burpLeaksScanner.analyzeProxyHistory(progressBar);
+                    burpLeaksScanner.analyzeProxyHistory(progressBar);
 
-                        btnAnalysis.setText(previousText);
-                        logTableEntryUI.setAutoCreateRowSorter(true);
-                        this.analyzeProxyHistoryThread = null;
-                        this.isAnalysisRunning = false;
-                    });
-                    this.analyzeProxyHistoryThread.start();
+                    btnAnalysis.setText(previousText);
+                    logTableEntryUI.setAutoCreateRowSorter(true);
+                    this.analyzeProxyHistoryThread = null;
+                    this.isAnalysisRunning = false;
+                });
+                this.analyzeProxyHistoryThread.start();
 
-                    //TODO: are they needed?
-                    logTableEntryUI.validate();
-                    logTableEntryUI.repaint();
-                }
+                //TODO: are they needed?
+                logTableEntryUI.validate();
+                logTableEntryUI.repaint();
             } else {
                 if (Objects.isNull(this.analyzeProxyHistoryThread)) return;
 
@@ -402,7 +400,6 @@ public class MainUI implements ITab {
             }
 
             extensionsList = BurpLeaksSeed.getExtensions();
-            burpLeaksScanner.updateExtensionList(extensionsList);
             modelExt.fireTableDataChanged();
 
             tabPaneOptions.validate();
@@ -438,7 +435,6 @@ public class MainUI implements ITab {
 
             if (ExtensionEntity.isExtensionValid(extension)) {
                 extensionsList.add(new ExtensionEntity(description, "\\" + extension));
-                burpLeaksScanner.updateExtensionList(extensionsList);
                 modelExt.fireTableDataChanged();
 
                 tabPaneOptions.validate();
@@ -455,7 +451,6 @@ public class MainUI implements ITab {
             int realRow = optionExtensionsTable.convertRowIndexToModel(rowIndex);
             extensionsList.remove(realRow);
 
-            burpLeaksScanner.updateExtensionList(extensionsList);
             modelExt.fireTableDataChanged();
 
             tabPaneOptions.validate();
@@ -470,7 +465,6 @@ public class MainUI implements ITab {
 
             if (extensionsList.size() > 0) {
                 extensionsList.subList(0, extensionsList.size()).clear();
-                burpLeaksScanner.updateExtensionList(extensionsList);
                 modelExt.fireTableDataChanged();
 
                 tabPaneOptions.validate();
@@ -506,7 +500,6 @@ public class MainUI implements ITab {
                     if (!extensionsList.contains(extension)) {
                         extensionsList.add(extension);
 
-                        this.burpLeaksScanner.updateExtensionList(extensionsList);
                         modelExt.fireTableDataChanged();
                     } else {
                         alreadyAdded.append(description).append(" - ").append(regex).append("\n");
@@ -598,7 +591,6 @@ public class MainUI implements ITab {
             }
 
             regexList = BurpLeaksSeed.getRegex();
-            this.burpLeaksScanner.updateRegexList(regexList);
             modelReg.fireTableDataChanged();
 
             tabPaneOptions.validate();
@@ -633,7 +625,6 @@ public class MainUI implements ITab {
             String description = textFieldDesc.getText();
 
             regexList.add(new RegexEntity(description, expression));
-            burpLeaksScanner.updateRegexList(regexList);
             modelReg.fireTableDataChanged();
 
             tabPaneOptions.validate();
@@ -647,7 +638,6 @@ public class MainUI implements ITab {
             int realRow = optionsRegexTable.convertRowIndexToModel(rowIndex);
             regexList.remove(realRow);
 
-            burpLeaksScanner.updateRegexList(regexList);
             modelReg.fireTableDataChanged();
 
             tabPaneOptions.validate();
@@ -662,7 +652,6 @@ public class MainUI implements ITab {
 
             if (regexList.size() > 0) {
                 regexList.subList(0, regexList.size()).clear();
-                burpLeaksScanner.updateRegexList(regexList);
                 modelReg.fireTableDataChanged();
 
                 tabPaneOptions.validate();
@@ -698,7 +687,6 @@ public class MainUI implements ITab {
                     if (!regexList.contains(newRegexEntity)) {
                         regexList.add(newRegexEntity);
 
-                        this.burpLeaksScanner.updateRegexList(regexList);
                         modelReg.fireTableDataChanged();
                     } else {
                         alreadyAdded.append(description).append(" - ").append(regex).append("\n");


### PR DESCRIPTION
The regexList and extensionsList are passed as a reference to the Scanner. The Scanner uses them while scanning, but if they change while scanning, problems occur.

With this fix, when an analysis is started, a copy of the current state is saved. Then, the Scanner uses this copy instead of the original list so that changes don't interfere with the analysis.